### PR TITLE
fix print syntax error

### DIFF
--- a/gk2qp.py
+++ b/gk2qp.py
@@ -176,7 +176,11 @@ def main(args):
 
     qp_notes, attachments = convert_notes(keepdir.glob('*.json'), tags)
 
-    print(f'Converted {len(qp_notes['notes'])} notes with {len(tags)} tags and {len(attachments)} attachments')
+    noteLen = len(qp_notes['notes'])
+    tagLen = len(tags)
+    attachmentLen = len(attachments)
+
+    print(f'Converted {noteLen} notes with {tagLen} tags and {attachmentLen} attachments')
 
     with open(dstdir / 'backup.json', 'w') as f:
         f.write(json.dumps(qp_notes))


### PR DESCRIPTION
Hello! I tried running the script on my machine and I got a syntax error for the print statement:
```
print(f'Converted {len(qp_notes['notes'])} notes with {len(tags)} tags and {len(attachments)} attachments')
                                     ^^^^^
SyntaxError: f-string: unmatched '['
```

I fixed the print statement by breaking down the operations.
